### PR TITLE
4: Removed eval from render array.

### DIFF
--- a/JSON.asp
+++ b/JSON.asp
@@ -164,7 +164,7 @@ Class jsCore
 
 			If Err = 9 Then
 				On Error GoTo 0
-				toJSON out, Eval("arr(" & parent & index & ")")
+				toJSON out, arr((parent & index).split(","))
 				out.WriteText limiter
 			Else
 				out.WriteText limiter

--- a/JSON.vbs
+++ b/JSON.vbs
@@ -163,7 +163,7 @@ Class jsCore
 
 			If Err = 9 Then
 				On Error GoTo 0
-				toJSON out, Eval("arr(" & parent & index & ")")
+				toJSON out, arr((parent & index).split(","))
 				out.WriteText limiter
 			Else
 				out.WriteText limiter


### PR DESCRIPTION
Resolves: #4 

~~Turns out, you can just pass an array to access a multi-dimensional array. Didn't know that until I tried it.~~