### PR TITLE
Encode key to avoid escaping vulnerability

### DIFF
--- a/JSON.asp
+++ b/JSON.asp
@@ -134,7 +134,7 @@ Class jsCore
 					Else
 						If QuotedVars Then
 							out.WriteText """"
-							out.WriteText i
+							out.WriteText jsEncode(i)
 							out.WriteText """:"
 							toJSON out, vPair(i)
 						Else

--- a/JSON.vbs
+++ b/JSON.vbs
@@ -133,7 +133,7 @@ Class jsCore
 					Else
 						If QuotedVars Then
 							out.WriteText """"
-							out.WriteText i
+							out.WriteText jsEncode(i)
 							out.WriteText """:"
 							toJSON out, vPair(i)
 						Else


### PR DESCRIPTION
It is possible to construct a key that may result in an XSS vulnerability if user data is used to construct JSON:

```asp
<!--#include file="JSON.asp"-->
<%
    Dim json
    Set json = jsObject()
    json("key"":""value"",""secondkey") = """"
    response.Write(json.jsString)
%>
```

This will result in output that breaks out of the first key:

```json
{"key":"value","secondkey":"\""}
```

The patch runs the (quoted) key through `jsEncode`, which results in the following:

```json
{"key\":\"value\",\"secondkey":"\""}
``` 